### PR TITLE
FIX #103: copy fully yaml from extraVolumeMounts

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -102,10 +102,8 @@ spec:
               mountPath: "/benthos.yaml"
               subPath: "benthos.yaml"
               readOnly: true
-            {{- range .Values.extraVolumeMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              readOnly: {{ .readOnly }}
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
             {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
             - name: streams

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -204,3 +204,33 @@ tests:
             - configMap:
                 name: my-config-map
               name: streams
+
+  - it: should include extraVolumeMounts
+    set:
+      deployment:
+        rolloutConfigMap: false
+        annotations:
+          - name: foo
+      extraVolumeMounts:
+        - mountPath: /mnt/configmap
+          name: config-map
+          readOnly: false
+          subPath: foo
+        - mountPath: /mnt/secret
+          name: secret
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: config
+              mountPath: "/benthos.yaml"
+              subPath: "benthos.yaml"
+              readOnly: true
+            - name: config-map
+              mountPath: /mnt/configmap
+              readOnly: false
+              subPath: foo
+            - mountPath: /mnt/secret
+              name: secret
+              readOnly: true


### PR DESCRIPTION
Copy full yaml for extraVolumeMounts, so it will support `subPath` (and future proof).

Added test cases that pass now.