### PR TITLE
Support templates for extraVolumes and extraVolumeMounts

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -105,6 +105,10 @@ spec:
             {{- if .Values.extraVolumeMounts }}
               {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+            {{- if .Values.extraVolumeMountsTemplate }}
+              {{- $extraVolumeMounts := tpl (.Values.extraVolumeMountsTemplate) . | fromYamlArray }}
+              {{- toYaml $extraVolumeMounts | nindent 12 }}
+            {{- end }}
             {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
             - name: streams
               mountPath: "/streams"
@@ -132,6 +136,10 @@ spec:
             name: {{ template "benthos.fullname" . }}-config
         {{- if .Values.extraVolumes }}
           {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.extraVolumesTemplate }}
+          {{- $extraVolumes := tpl (.Values.extraVolumesTemplate) . | fromYamlArray }}
+          {{- toYaml $extraVolumes | nindent 8 }}
         {{- end }}
         {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
         - name: streams

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -251,3 +251,41 @@ tests:
             - configMap:
                 name: my-config-map
               name: streams
+
+  - it: should allow templated volumes and volume mounts
+    set:
+      global:
+        subPath: "some-subpath"
+        pvcName: "some-pvc"
+      deployment:
+        rolloutConfigMap: false
+      extraVolumeMountsTemplate: |
+        - mountPath: /testing
+          name: test
+          readOnly: true
+          subPath: {{ .Values.global.subPath | quote }}
+      extraVolumesTemplate: |
+        - name: test
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.pvcName | quote }}
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /benthos.yaml
+              name: config
+              readOnly: true
+              subPath: benthos.yaml
+            - mountPath: /testing
+              name: test
+              readOnly: true
+              subPath: "some-subpath"
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - configMap:
+                name: RELEASE-NAME-benthos-config
+              name: config
+            - name: test
+              persistentVolumeClaim:
+                claimName: "some-pvc"

--- a/values.yaml
+++ b/values.yaml
@@ -188,6 +188,7 @@ extraVolumes:
   # - name: secret
   #   secret:
   #     secretName: s-name
+extraVolumesTemplate:
 
 extraVolumeMounts:
   []
@@ -197,6 +198,7 @@ extraVolumeMounts:
   # - name: secret
   #   mountPath: /mnt/secret
   #   readOnly: true
+extraVolumeMountsTemplate:
 
 streams:
   enabled: false


### PR DESCRIPTION
Allow additional, optional parameters for `extraVolumesTemplate` and `extraVolumeMountsTemplate`, to include templated values (to be able to include other helm values in those templates).

These *Template values are separate than their normal ones to only for more robust handling with `tpl` function.
