### PR TITLE
feat: refresh chart to use latest connect version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: benthos
-description: Benthos Helm chart for Kubernetes
+name: connect
+description: Redpanda Connect Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -21,4 +21,4 @@ version: 2.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.24.0"
+appVersion: "4.38.0"

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# benthos-helm-chart
+# Redpanda Connect Helm Chart Specification
 <p align="center" style="text-align: center">
     <img src="./assets/blob.png" width="30%"><br/>
-    Benthos Helm Chart. <br/>
+    Redpanda Connect Helm Chart. <br/>
 </p>
 
-Benthos is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
+Redpanda Connect is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
 
-This Helm Chart deploys a single Benthos instance in either streams mode or standalone.
+This Helm Chart deploys a single Redpanda Connect instance in either streams mode or standalone.
 
 ## Installation
 ```bash
-helm repo add benthos https://benthosdev.github.io/charts/
+helm repo add redpanda https://benthosdev.github.io/charts/
 helm repo update
 
-helm install benthos/benthos
+helm install redpanda/connect
 ```
 
 ## Configuration
 
-The config parameter should contain the configuration as it would be parsed by the Benthos binary.
+The config parameter should contain the configuration as it would be parsed by the Redpanda Connect binary.
 ```yaml
 # values.yaml
 config:
   input:
     label: "no_config_in"
     generate:
-      mapping: root = "This Benthos instance is unconfigured!"
+      mapping: root = "This Redpanda Connect instance is unconfigured!"
       interval: 1m
   output:
     label: "no_config_out"
@@ -33,17 +33,17 @@ config:
       codec: lines
 ```
 
-The full list of [available configuration for the Helm Chart can be found in the `values.yaml` file](./values.yaml). You should refer to the [upstream Benthos documentation](https://www.benthos.dev/docs/configuration/about) for the configuration of your pipeline.
+The full list of [available configuration for the Helm Chart can be found in the `values.yaml` file](./values.yaml). You should refer to the [upstream Redpanda Connect documentation](https://docs.redpanda.com/redpanda-connect/configuration/about/) for the configuration of your pipeline.
 
 ## Streams mode
 
-When running Benthos in [streams mode](https://www.benthos.dev/docs/guides/streams_mode/about), all individual stream configuration files should be combined and placed in a single Kubernetes `ConfigMap`, like so:
+When running Redpanda Connect in [streams mode](https://docs.redpanda.com/redpanda-connect/guides/streams_mode/about/), all individual stream configuration files should be combined and placed in a single Kubernetes `ConfigMap`, like so:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: benthos-streams
+  name: connect-streams
 data:
   hello.yaml: |
     input:
@@ -70,16 +70,16 @@ Then you can simply reference your `ConfigMap` and enable streams mode in your `
 # values.yaml
 streams:
   enabled: true
-  streamsConfigMap: "benthos-streams"
+  streamsConfigMap: "connect-streams"
 ```
 
 Currently the streams mode `ConfigMap` should be applied **separately from and before installation of** the helm chart; support for deploying additional `ConfigMap`'s within the chart may be implemented later.
 
 ### Global Configuration
 
-When deploying Benthos in streams mode, you may want to configure global tracing, logging and http configuration which is shared across all of your pipelines.
+When deploying Redpanda Connect in streams mode, you may want to configure global tracing, logging and http configuration which is shared across all of your pipelines.
 
-This can be done by specifying configuration under the `metrics`, `logger` and `tracing` configuration sections in your `values.yaml` file. These all use their respective upstream Benthos configuration syntax.
+This can be done by specifying configuration under the `metrics`, `logger` and `tracing` configuration sections in your `values.yaml` file. These all use their respective upstream Redpanda Connect configuration syntax.
 
 ```yaml
 metrics:
@@ -94,5 +94,5 @@ tracing:
 logger:
   level: INFO
   static_fields:
-    '@service': benthos
+    '@service': redpanda-connect
 ```

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "benthos.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "redpanda-connect.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "benthos.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "benthos.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "redpanda-connect.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "redpanda-connect.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "benthos.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "redpanda-connect.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "benthos.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- define "redpanda-connect.name" -}}
+{{- default "redpanda-connect" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -10,11 +10,11 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "benthos.fullname" -}}
+{{- define "redpanda-connect.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default "redpanda-connect" .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "benthos.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- define "redpanda-connect.chart" -}}
+{{- printf "%s-%s" "redpanda-connect" .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "benthos.labels" -}}
-helm.sh/chart: {{ include "benthos.chart" . }}
-{{ include "benthos.selectorLabels" . }}
+{{- define "redpanda-connect.labels" -}}
+helm.sh/chart: {{ include "redpanda-connect.chart" . }}
+{{ include "redpanda-connect.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -48,17 +48,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "benthos.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "benthos.name" . }}
+{{- define "redpanda-connect.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redpanda-connect.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "benthos.serviceAccountName" -}}
+{{- define "redpanda-connect.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "benthos.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "redpanda-connect.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "benthos.fullname" . }}-config
+  name: {{ template "redpanda-connect.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
 data:
-  benthos.yaml: |
+  redpanda-connect.yaml: |
     {{- with .Values.logger }}
     logger:
-      {{- toYaml . | nindent 6}} 
+      {{- toYaml . | nindent 6}}
     {{- end }}
     {{- with .Values.metrics }}
     metrics:
-      {{- toYaml . | nindent 6}} 
+      {{- toYaml . | nindent 6}}
     {{- end }}
     {{- with .Values.tracing }}
     tracer:
@@ -38,7 +38,7 @@ data:
     input:
       label: "no_config_in"
       generate:
-        mapping: root = "This Benthos instance is unconfigured!"
+        mapping: root = "This Redpanda Connect instance is unconfigured!"
         interval: 1m
     output:
       label: "no_config_out"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "benthos.fullname" . }}
+  name: {{ include "redpanda-connect.fullname" . }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.deployment.annotations | nindent 4 }}
 spec:
@@ -12,7 +12,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "benthos.selectorLabels" . | nindent 6 }}
+      {{- include "redpanda-connect.selectorLabels" . | nindent 6 }}
   {{- with .Values.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -27,7 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "benthos.selectorLabels" . | nindent 8 }}
+        {{- include "redpanda-connect.selectorLabels" . | nindent 8 }}
         {{- with .Values.deployment.podLabels }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -36,7 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "benthos.serviceAccountName" . }}
+      serviceAccountName: {{ include "redpanda-connect.serviceAccountName" . }}
       restartPolicy: {{ .Values.deployment.restartPolicy }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -61,7 +61,7 @@ spec:
           {{- else }}
           args:
             - "-c"
-            - "/benthos.yaml"
+            - "/redpanda-connect.yaml"
             {{- if eq .Values.watch true}}
             - -w
             {{- end }}
@@ -99,8 +99,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: "/benthos.yaml"
-              subPath: "benthos.yaml"
+              mountPath: "/redpanda-connect.yaml"
+              subPath: "redpanda-connect.yaml"
               readOnly: true
             {{- if .Values.extraVolumeMounts }}
               {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -129,7 +129,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ template "benthos.fullname" . }}-config
+            name: {{ template "redpanda-connect.fullname" . }}-config
         {{- if .Values.extraVolumes }}
           {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "benthos.fullname" . }}
+  name: {{ include "redpanda-connect.fullname" . }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "benthos.fullname" . }}
+    name: {{ include "redpanda-connect.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   {{- with .Values.autoscaling.metrics }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.http.enabled) (.Values.ingress.enabled) -}}
-{{- $fullName := include "benthos.fullname" . -}}
+{{- $fullName := include "redpanda-connect.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -2,9 +2,9 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "benthos.fullname" . }}
+  name: {{ template "redpanda-connect.fullname" . }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:
 {{- with .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}
@@ -14,5 +14,5 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      {{- include "benthos.selectorLabels" . | nindent 6 }}
+      {{- include "redpanda-connect.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "benthos.fullname" . }}
+  name: {{ include "redpanda-connect.fullname" . }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -17,5 +17,5 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
-    {{- include "benthos.selectorLabels" . | nindent 4 }}
+    {{- include "redpanda-connect.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "benthos.serviceAccountName" . }}
+  name: {{ include "redpanda-connect.serviceAccountName" . }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -2,9 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "benthos.fullname" . }}
+  name: {{ include "redpanda-connect.fullname" . }}
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval}}
@@ -24,5 +24,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "benthos.selectorLabels" . | nindent 6 }}
+      {{- include "redpanda-connect.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "benthos.fullname" . }}-test-connection"
+  name: "{{ include "redpanda-connect.fullname" . }}-test-connection"
   labels:
-    {{- include "benthos.labels" . | nindent 4 }}
+    {{- include "redpanda-connect.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
     "kube-linter.io/ignore-all": "Linter does not need to run on this test"
@@ -12,5 +12,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "benthos.fullname" . }}:{{ .Values.service.port }}/ping']
+      args: ['{{ include "redpanda-connect.fullname" . }}:{{ .Values.service.port }}/ping']
   restartPolicy: Never

--- a/tests/__snapshot__/configuration_test.yaml.snap
+++ b/tests/__snapshot__/configuration_test.yaml.snap
@@ -1,12 +1,12 @@
 can set global options with streams mode:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       logger:
         add_timestamp: false
         format: logfmt
         level: INFO
         static_fields:
-          '@service': benthos
+          '@service': redpanda-connect
       metrics:
         statsd:
           address: localhost:8125
@@ -31,17 +31,17 @@ can set global options with streams mode:
         debug_endpoints: false
         enabled: true
         key_file: /my/cert.key
-        root_path: /benthos
+        root_path: /redpanda-connect
 should set config from string:
   1: |
-    benthos.yaml: |
+    redpanda-connect.yaml: |
       http:
         address: 0.0.0.0:4195
         cors:
           enabled: false
         debug_endpoints: false
         enabled: true
-        root_path: /benthos
+        root_path: /redpanda-connect
       input:
         nats_jetstream:
           urls: [ nats://TODO:4222 ]
@@ -75,14 +75,14 @@ should set config from string:
           max_in_flight: 64
 should set config from yaml:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       http:
         address: 0.0.0.0:4195
         cors:
           enabled: false
         debug_endpoints: false
         enabled: true
-        root_path: /benthos
+        root_path: /redpanda-connect
       buffer:
         system_window:
           size: 1h
@@ -114,18 +114,18 @@ should set config from yaml:
             } else { deleted() }
 should set default configuration:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       http:
         address: 0.0.0.0:4195
         cors:
           enabled: false
         debug_endpoints: false
         enabled: true
-        root_path: /benthos
+        root_path: /redpanda-connect
       input:
         label: "no_config_in"
         generate:
-          mapping: root = "This Benthos instance is unconfigured!"
+          mapping: root = "This Redpanda Connect instance is unconfigured!"
           interval: 1m
       output:
         label: "no_config_out"
@@ -133,7 +133,7 @@ should set default configuration:
           codec: lines
 should set http options:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       http:
         address: 127.0.0.0:4095
         basic_auth:
@@ -149,11 +149,11 @@ should set http options:
         debug_endpoints: false
         enabled: true
         key_file: /my/cert.key
-        root_path: /benthos
+        root_path: /redpanda-connect
       input:
         label: "no_config_in"
         generate:
-          mapping: root = "This Benthos instance is unconfigured!"
+          mapping: root = "This Redpanda Connect instance is unconfigured!"
           interval: 1m
       output:
         label: "no_config_out"
@@ -161,24 +161,24 @@ should set http options:
           codec: lines
 should set logging options:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       logger:
         add_timestamp: false
         format: logfmt
         level: INFO
         static_fields:
-          '@service': benthos
+          '@service': redpanda-connect
       http:
         address: 0.0.0.0:4195
         cors:
           enabled: false
         debug_endpoints: false
         enabled: true
-        root_path: /benthos
+        root_path: /redpanda-connect
       input:
         label: "no_config_in"
         generate:
-          mapping: root = "This Benthos instance is unconfigured!"
+          mapping: root = "This Redpanda Connect instance is unconfigured!"
           interval: 1m
       output:
         label: "no_config_out"
@@ -186,7 +186,7 @@ should set logging options:
           codec: lines
 should set metrics options:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       metrics:
         statsd:
           address: localhost:8125
@@ -197,11 +197,11 @@ should set metrics options:
           enabled: false
         debug_endpoints: false
         enabled: true
-        root_path: /benthos
+        root_path: /redpanda-connect
       input:
         label: "no_config_in"
         generate:
-          mapping: root = "This Benthos instance is unconfigured!"
+          mapping: root = "This Redpanda Connect instance is unconfigured!"
           interval: 1m
       output:
         label: "no_config_out"
@@ -209,7 +209,7 @@ should set metrics options:
           codec: lines
 should set tracing options:
   1: |
-    benthos.yaml: |-
+    redpanda-connect.yaml: |-
       tracer:
         jaeger:
           agent_address: localhost:6831
@@ -221,11 +221,11 @@ should set tracing options:
           enabled: false
         debug_endpoints: false
         enabled: true
-        root_path: /benthos
+        root_path: /redpanda-connect
       input:
         label: "no_config_in"
         generate:
-          mapping: root = "This Benthos instance is unconfigured!"
+          mapping: root = "This Redpanda Connect instance is unconfigured!"
           interval: 1m
       output:
         label: "no_config_out"

--- a/tests/__snapshot__/hpa_test.yaml.snap
+++ b/tests/__snapshot__/hpa_test.yaml.snap
@@ -25,7 +25,7 @@ should configure autoscaler custom:
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
-      name: RELEASE-NAME-benthos
+      name: RELEASE-NAME-redpanda-connect
 should enable autoscaler default:
   1: |
     maxReplicas: 12
@@ -40,4 +40,4 @@ should enable autoscaler default:
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
-      name: RELEASE-NAME-benthos
+      name: RELEASE-NAME-redpanda-connect

--- a/tests/__snapshot__/ingress_test.yaml.snap
+++ b/tests/__snapshot__/ingress_test.yaml.snap
@@ -6,7 +6,7 @@ should enable ingress default:
           paths:
             - backend:
                 service:
-                  name: RELEASE-NAME-benthos
+                  name: RELEASE-NAME-redpanda-connect
                   port:
                     number: 80
               path: /

--- a/tests/__snapshot__/service_test.yaml.snap
+++ b/tests/__snapshot__/service_test.yaml.snap
@@ -11,7 +11,7 @@ should enable service custom:
         targetPort: 9999
     selector:
       app.kubernetes.io/instance: RELEASE-NAME
-      app.kubernetes.io/name: benthos
+      app.kubernetes.io/name: redpanda-connect
     type: LoadBalancer
 should enable service default:
   1: |
@@ -22,5 +22,5 @@ should enable service default:
         targetPort: http
     selector:
       app.kubernetes.io/instance: RELEASE-NAME
-      app.kubernetes.io/name: benthos
+      app.kubernetes.io/name: redpanda-connect
     type: ClusterIP

--- a/tests/configuration_test.yaml
+++ b/tests/configuration_test.yaml
@@ -33,7 +33,7 @@ tests:
         format: logfmt
         add_timestamp: false
         static_fields:
-          "@service": benthos
+          "@service": redpanda-connect
     asserts:
       - matchSnapshot:
           path: data
@@ -82,7 +82,7 @@ tests:
         format: logfmt
         add_timestamp: false
         static_fields:
-          "@service": benthos
+          "@service": redpanda-connect
       tracing:
         jaeger:
           agent_address: localhost:6831

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -144,16 +144,16 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - -c
-            - /benthos.yaml
+            - /redpanda-connect.yaml
             - streams
             - /streams/*.yaml
       - equal:
           path: spec.template.spec.containers[0].volumeMounts
           value:
-            - mountPath: /benthos.yaml
+            - mountPath: /redpanda-connect.yaml
               name: config
               readOnly: true
-              subPath: benthos.yaml
+              subPath: redpanda-connect.yaml
             - mountPath: /streams
               name: streams
               readOnly: true
@@ -161,7 +161,7 @@ tests:
           path: spec.template.spec.volumes
           value:
             - configMap:
-                name: RELEASE-NAME-benthos-config
+                name: RELEASE-NAME-redpanda-connect-config
               name: config
             - configMap:
                 name: my-config-map
@@ -181,17 +181,17 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - -c
-            - /benthos.yaml
+            - /redpanda-connect.yaml
             - streams
             - --no-api
             - /streams/*.yaml
       - equal:
           path: spec.template.spec.containers[0].volumeMounts
           value:
-            - mountPath: /benthos.yaml
+            - mountPath: /redpanda-connect.yaml
               name: config
               readOnly: true
-              subPath: benthos.yaml
+              subPath: redpanda-connect.yaml
             - mountPath: /streams
               name: streams
               readOnly: true
@@ -199,7 +199,7 @@ tests:
           path: spec.template.spec.volumes
           value:
             - configMap:
-                name: RELEASE-NAME-benthos-config
+                name: RELEASE-NAME-redpanda-connect-config
               name: config
             - configMap:
                 name: my-config-map
@@ -224,17 +224,17 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - -c
-            - /benthos.yaml
+            - /redpanda-connect.yaml
             - streams
             - --no-api
             - /streams/*.yaml
       - equal:
           path: spec.template.spec.containers[0].volumeMounts
           value:
-            - mountPath: /benthos.yaml
+            - mountPath: /redpanda-connect.yaml
               name: config
               readOnly: true
-              subPath: benthos.yaml
+              subPath: redpanda-connect.yaml
             - mountPath: /testing
               name: test
               readOnly: true
@@ -246,7 +246,7 @@ tests:
           path: spec.template.spec.volumes
           value:
             - configMap:
-                name: RELEASE-NAME-benthos-config
+                name: RELEASE-NAME-redpanda-connect-config
               name: config
             - configMap:
                 name: my-config-map

--- a/values.yaml
+++ b/values.yaml
@@ -117,7 +117,7 @@ env: []
 envFrom:
   []
   # - secretRef:
-  #     name: redp
+  #     name: redpanda
 
 resources:
   {}

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Default values for benthos.
+# Default values for Redpanda Connect.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -6,7 +6,7 @@ deployment:
   replicaCount: 1
   podAnnotations: {}
   podLabels: {}
-  # annotations -- Set annotations on the Benthos Deployment
+  # annotations -- Set annotations on the Redpanda Connect Deployment
   annotations: {}
   # Default 60. ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   terminationGracePeriodSeconds: 60
@@ -45,7 +45,7 @@ deployment:
 commonLabels: {}
 
 image:
-  repository: "jeffail/benthos"
+  repository: "docker.redpanda.com/redpandadata/connect"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -117,7 +117,7 @@ env: []
 envFrom:
   []
   # - secretRef:
-  #     name: benthos
+  #     name: redp
 
 resources:
   {}
@@ -164,14 +164,14 @@ tolerations: []
 affinity: {}
 
 podDisruptionBudget:
-  # podDisruptionBudget.enabled -- Enable a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for Benthos.
+  # podDisruptionBudget.enabled -- Enable a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for Redpanda Connect.
   enabled: false
   # podDisruptionBudget.minAvailable -- The number of Pods that must still be available after an eviction.
   # minAvailable: 1
   # podDisruptionBudget.maxUnavailable -- (int) The number of Pods that can be unavailable after an eviction.
   # maxUnavailable: 1
 
-# initContainers -- Init Containers to be added to the Benthos Pods.
+# initContainers -- Init Containers to be added to the Redpanda Connect Pods.
 initContainers: []
 
 # DeploymentStrategy: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/
@@ -204,12 +204,12 @@ streams:
   api:
     enable: true
 
-  # /benthos.yaml HTTP configuration
+  # /redpanda-connect.yaml HTTP configuration
 http:
   # Disabling HTTP server will prevent service and ingress objects from being created.
   enabled: true
   address: "0.0.0.0:4195"
-  root_path: "/benthos"
+  root_path: "/redpanda-connect"
   debug_endpoints: false
   cors:
     enabled: false
@@ -240,12 +240,12 @@ serviceMonitor:
 # logger:
 #   level: INFO
 #   static_fields:
-#     '@service': benthos
+#     '@service': redpanda-connect
 
 # command -- Command replaces the entrypoint command of the docker
 command: []
 
-# args -- Override Benthos's default arguments passed with command.
+# args -- Override Redpanda Connect's default arguments passed with command.
 args: []
 
 # EXPERIMENTAL: watch config files for changes and automatically apply them
@@ -254,5 +254,5 @@ watch: false
 # Spread  incoming Pod in relation to the existing Pods across your cluster. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
 topologySpreadConstraints: []
 
-# /benthos.yaml configuration
+# /redpanda-connect.yaml configuration
 config: {}


### PR DESCRIPTION
After this PR is merged, I will move the contents of this repo to [the main charts repo](https://github.com/redpanda-data/helm-charts/tree/main/charts) to keep it in line with everything else. After that we should archive this repo and put a notice pointing to the new location.